### PR TITLE
dont filter out none

### DIFF
--- a/src/function_invocable.py
+++ b/src/function_invocable.py
@@ -76,9 +76,9 @@ class FunctionInvocable:
             raise Exception('Cannot execute injected function')
         try:
             if inspect.isgeneratorfunction(self._func):
-                result_exp = filter(lambda x: x is not None, self._func(data_in['data']))
+                result_exp = self._func(data_in['data'])
             else:
-                result_exp = (r for r in [self._func(data_in['data'])] if r is not None)
+                result_exp = (r for r in [self._func(data_in['data'])])
 
             for result in result_exp:
                 yield {'data': result, 'log': log(data_in.get('log', []))}

--- a/src/version.py
+++ b/src/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.4.16-alpha'
+VERSION = '0.4.17-alpha'
 
 
 def get_version() -> str:


### PR DESCRIPTION
## Description

Reverts https://github.com/mattian7741/ergo/pull/4 since desired behavior (`filter`ing results) is doable via generator expression.

## Testing

tested w function:
```
def is_even(payload):
    num = payload['num']
    if num % 2 == 0:
        yield f'{num} is even'
```

and verified after publishing multiple messages only even numbers filtered through.