### PR TITLE
feat: config to allow custom json encoder

### DIFF
--- a/src/amqp_invoker.py
+++ b/src/amqp_invoker.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 import pika
 
 from src.invoker import Invoker
-from src.types import TYPE_PAYLOAD
+from src.types import TYPE_RETURN
 
 # content_type: application/json
 # {"x":5,"y":7}
@@ -52,7 +52,7 @@ class AmqpInvoker(Invoker):
                 properties (TYPE): Description
                 body (TYPE): Description
             """
-            data_in: TYPE_PAYLOAD = dict(json.loads(body.decode('utf-8')))
+            data_in: TYPE_RETURN = dict(json.loads(body.decode('utf-8')))
             data_in['key'] = str(self._invocable.config.subtopic)
             try:
                 for data_out in self._invocable.invoke(data_in):

--- a/src/amqp_invoker.py
+++ b/src/amqp_invoker.py
@@ -56,8 +56,8 @@ class AmqpInvoker(Invoker):
             data_in['key'] = str(self._invocable.config.subtopic)
             try:
                 for data_out in self._invocable.invoke(data_in):
-                    data_out['key'] = str(self._invocable.config.pubtopic)
-                    channel.basic_publish(exchange=self._invocable.config.exchange, routing_key=str(self._invocable.config.pubtopic), body=json.dumps(data_out))
+                    data_out.set('key', str(self._invocable.config.pubtopic))
+                    channel.basic_publish(exchange=self._invocable.config.exchange, routing_key=str(self._invocable.config.pubtopic), body=str(data_out))
             except Exception as err:  # pylint: disable=broad-except
                 data_in['error'] = str(err)
                 channel.basic_publish(exchange='', routing_key=queue_name_error, body=json.dumps(data_in))

--- a/src/config.py
+++ b/src/config.py
@@ -58,7 +58,7 @@ class Config:
         """Summary.
 
         Returns:
-            TYPE: Description
+            TYPE: Source reference to a `Callable` attribute
         """
         return self._func
 
@@ -103,7 +103,7 @@ class Config:
         """Summary.
 
         Returns:
-            TYPE: Description
+            TYPE: Source reference to an attribute conforming to protocol `json.JSONEncoder`
         """
         return self._encoder
 

--- a/src/config.py
+++ b/src/config.py
@@ -17,16 +17,17 @@ class Config:
             config (Dict[str, str]): Description
         """
         self._func: str = config['func']
-        self._namespace: Optional[str] = config.get('namespace', 'local')
+        self._namespace: str = config.get('namespace', 'local')
         self._pubtopic: Topic = PubTopic(config.get('pubtopic'))
         self._subtopic: Topic = SubTopic(config.get('subtopic'))
         self._host: Optional[str] = config.get('host')
         self._exchange: Optional[str] = config.get('exchange')
         self._protocol: str = config.get('protocol', 'stack')  # http, amqp, stdio, stack
         self._heartbeat: Optional[str] = config.get('heartbeat')
+        self._encoder: Optional[str] = config.get('encoder')
 
     @property
-    def namespace(self) -> Optional[str]:
+    def namespace(self) -> str:
         """Summary.
 
         Returns:
@@ -96,3 +97,14 @@ class Config:
             TYPE: Description
         """
         return int(self._heartbeat) if self._heartbeat else None
+
+    @property
+    def encoder(self) -> Optional[str]:
+        """Summary.
+
+        Returns:
+            TYPE: Description
+        """
+        return self._encoder
+
+

--- a/src/falcon_http_invoker.py
+++ b/src/falcon_http_invoker.py
@@ -3,6 +3,7 @@
 # type: ignore
 """Summary."""
 
+from src.types import TYPE_PAYLOAD
 from typing import Any, List
 
 from falcon import Request, Response, abort
@@ -29,7 +30,7 @@ class FalconHttpInvoker(HttpInvoker):
             request (Request): Description
             response (Response): Description
         """
-        data_out: List[Any] = []
+        data_out: List[TYPE_PAYLOAD] = []
         data_in: List[Any] = request.params
         # data_in(f'route: {str(request.url_rule)}')
         try:

--- a/src/flask_http_invoker.py
+++ b/src/flask_http_invoker.py
@@ -4,7 +4,7 @@ from typing import List
 from flask import Flask, request  # , abort
 
 from src.http_invoker import HttpInvoker
-from src.types import TYPE_PAYLOAD
+from src.types import TYPE_PAYLOAD, TYPE_RETURN
 
 
 class FlaskHttpInvoker(HttpInvoker):
@@ -28,7 +28,7 @@ class FlaskHttpInvoker(HttpInvoker):
 
             """
             data_out: List[TYPE_PAYLOAD] = []
-            data_in: TYPE_PAYLOAD = dict(request.args)
+            data_in: TYPE_RETURN = dict(request.args)
             # data_in(f'route: {str(request.url_rule)}')
             # try:
             for result in self._invocable.invoke(data_in):

--- a/src/function_invocable.py
+++ b/src/function_invocable.py
@@ -64,7 +64,7 @@ class FunctionInvocable:
         Raises:
             Exception:
                 * caught exception re-raised with a stack trace.
-                * function was not specified in configuration and cannot be invoked
+                * function source reference was invalid and cannot be invoked.
 
         """
         if not self._func:

--- a/src/payload.py
+++ b/src/payload.py
@@ -17,14 +17,14 @@ class Payload:
         self._data: Dict[str, Any] = data or {}
         self._encoder: Optional[Type[json.JSONEncoder]] = encoder
 
-    def get(self, key: str) -> Optional[str]:
+    def get(self, key: str) -> Optional[Any]:
         """Summary.
 
         Args:
             key (str): Description
 
         Returns:
-            Optional[str]: Description
+            Optional[Any]: Description
 
         """
         return self._data.get(key)

--- a/src/payload.py
+++ b/src/payload.py
@@ -1,19 +1,21 @@
 """Summary."""
 import json
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Type
 
 
 class Payload:
     """Summary."""
 
-    def __init__(self, data: Optional[Dict[str, str]] = None) -> None:
+    def __init__(self, data: Optional[Dict[str, Any]] = None, encoder=None) -> None:
         """Summary.
 
         Args:
-            data (Optional[Dict[str, str]], optional): Description
+            data (Optional[Dict[str, Any]], optional): Description
+            encoder (Optional[Type[json.JSONEncoder]], optional): Description
 
         """
-        self._data: Dict[str, str] = data or {}
+        self._data: Dict[str, Any] = data or {}
+        self._encoder: Optional[Type[json.JSONEncoder]] = encoder
 
     def get(self, key: str) -> Optional[str]:
         """Summary.
@@ -27,21 +29,21 @@ class Payload:
         """
         return self._data.get(key)
 
-    def set(self, key: str, value: str) -> None:
+    def set(self, key: str, value: Any) -> None:
         """Summary.
 
         Args:
             key (str): Description
-            value (str): Description
+            value (Any): Description
 
         """
         self._data[key] = value
 
-    def list(self) -> List[str]:
+    def list(self) -> List[Any]:
         """Summary.
 
         Returns:
-            List[str]: Description
+            List[Any]: Description
 
         """
         return list(self._data.values())
@@ -50,7 +52,7 @@ class Payload:
         """Summary.
 
         Returns:
-            str: Description
+            str: JSON string representation of data
 
         """
-        return json.dumps(self._data)
+        return json.dumps(self._data, cls=self._encoder)

--- a/src/types.py
+++ b/src/types.py
@@ -1,11 +1,12 @@
 """Summary.
 
 Attributes:
-    TYPE_RETURN (TYPE): Description
+    TYPE_RETURN (TYPE): Return value from bound function
+    TYPE_PAYLOAD (TYPE): Standardized payload object
 
 """
+from typing import Any, Dict
 from src.payload import Payload
-from typing import Any
 
-TYPE_RETURN = Payload
-TYPE_PAYLOAD = Any
+TYPE_RETURN = Dict[str, Any]
+TYPE_PAYLOAD = Payload

--- a/src/types.py
+++ b/src/types.py
@@ -4,7 +4,8 @@ Attributes:
     TYPE_RETURN (TYPE): Description
 
 """
+from src.payload import Payload
 from typing import Any
 
-TYPE_RETURN = Any
+TYPE_RETURN = Payload
 TYPE_PAYLOAD = Any

--- a/src/util.py
+++ b/src/util.py
@@ -137,5 +137,5 @@ def load_source(ref: str) -> Any:
         class_name: str = match[:-1]
         scope = getattr(scope, class_name)
 
-    method_name = matches.group(5)
+    method_name: str = matches.group(5)
     return getattr(scope, method_name)

--- a/src/util.py
+++ b/src/util.py
@@ -112,7 +112,7 @@ def print_exc_plus() -> str:  # pragma: no cover
 
 
 def load_source(ref: str) -> Any:
-    pattern: str = r'^(.*\/)?([^\.\/]+)\.([^\.]+):([^:]+\.)?([^:\.]+)$'  # (path/to/file/)(file).(extension):(method)
+    pattern: str = r'^(.*\/)?([^\.\/]+)\.([^\.]+):([^:]+\.)?([^:\.]+)$'
     matches: Optional[Match[str]] = re.match(pattern, ref)
     if not matches:
         raise Exception(f'Invalid source reference pattern {ref}, must conform to [path/to/file/]<file>.<extension>[:[class.]method]]')
@@ -138,7 +138,4 @@ def load_source(ref: str) -> Any:
         scope = getattr(scope, class_name)
 
     method_name = matches.group(5)
-    if method_name is not None:
-        return getattr(scope, method_name)
-    else:
-        return scope # return class_name if no method exists
+    return getattr(scope, method_name)

--- a/test/integration/target.py
+++ b/test/integration/target.py
@@ -1,0 +1,6 @@
+def product(x, y):
+    return float(x) * float(y)
+
+class Product:
+	def __call__(self, x, y) -> float:
+		return product(x, y)

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 import src.util as util
 
@@ -50,3 +51,8 @@ class TestUtil(unittest.TestCase):
 
         # load invalid pattern
         self.assertRaises(Exception, util.load_source, "test/integration/.target:py.__Product__+call")
+
+        # load relative path
+        os.chdir("test/integration")
+        mod = util.load_source("target.py:product")
+        assert mod is not None

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -43,3 +43,10 @@ class TestUtil(unittest.TestCase):
         product_cls = util.load_source("test/integration/target.py:Product")
         assert isinstance(product_cls(), object)
         assert product_cls()(4, 5) == 20
+
+        # load classmethod
+        product_call = util.load_source("test/integration/target.py:Product.__call__")
+        assert product_call(product_cls(), 4, 5) == 20
+
+        # load invalid pattern
+        self.assertRaises(Exception, util.load_source, "test/integration/.target:py.__Product__+call")

--- a/test/unit/test_util.py
+++ b/test/unit/test_util.py
@@ -1,4 +1,3 @@
-import sys
 import unittest
 import src.util as util
 
@@ -33,3 +32,14 @@ class TestUtil(unittest.TestCase):
         frames = f1()
         for code, frame in zip(['f3', 'f2', 'f1'], frames):
             assert code in str(frame.f_code), f'code is: {code}, frame is: {frame}'
+
+    def test_load_source(self):
+        # load callable
+        product = util.load_source("test/integration/target.py:product")
+        assert product is not None
+        assert product(4, 5) == 20
+
+        # load classname
+        product_cls = util.load_source("test/integration/target.py:Product")
+        assert isinstance(product_cls(), object)
+        assert product_cls()(4, 5) == 20


### PR DESCRIPTION
**Changes**
* Add config entry to allow specifying a reference to a compliant JSONEncoder, in the same way for a function
* Un-stub `Payload` and use as standard return value for `FunctionInvocable`
* Code-org - move module/code loading to `utils.py`