### PR TITLE
fix(amqp_invoker): better catch-all amqp exception retries

### DIFF
--- a/src/version.py
+++ b/src/version.py
@@ -7,7 +7,7 @@ Attributes:
 import subprocess
 import sys
 
-VERSION = '0.5.3-alpha'
+VERSION = '0.5.4-alpha'
 
 
 def get_version() -> str:


### PR DESCRIPTION
Now catching base `AMQPError`, since `AMQPConnectionError` was a bit too specific to the `connection` handle.

Also the occasional `ChannelInvalidStateError` inherits from `RuntimeError`.